### PR TITLE
Circleci - remove git+ in package.json which is breaking the build

### DIFF
--- a/twitter-bot/.circleci/config.yml
+++ b/twitter-bot/.circleci/config.yml
@@ -2,6 +2,10 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
+machine:
+  node:
+    version: 10.4.0
+
 version: 2
 jobs:
   build:

--- a/twitter-bot/package.json
+++ b/twitter-bot/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/joshheath/MA_final_project.git"
+    "url": "https://github.com/joshheath/MA_final_project.git"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
We're seeing lots of build errors, the solution to which is outlined in this doc:

https://circleci.com/docs/1.0/git-npm-install/
